### PR TITLE
add default label value to Keypoint class

### DIFF
--- a/imgaug/augmentables/kps.py
+++ b/imgaug/augmentables/kps.py
@@ -89,7 +89,7 @@ class Keypoint(object):
 
     """
 
-    def __init__(self, x, y, label):
+    def __init__(self, x, y, label=None):
         self.x = x
         self.y = y
         self.label = label


### PR DESCRIPTION
fixes: BoundingBox uses Keypoint, breaks when Keypoints are initialized without labels